### PR TITLE
Fix issue where circle.yml missing jobs key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,8 +173,9 @@ async function buildConfiguration(
     mergeObject('executors', circleConfig)
     mergeObject('commands', circleConfig)
 
+    // jobs may be missing from circle config if all workflow jobs are from orbs
     const jobs = circleConfig.jobs as Record<string, { conditional?: boolean }>
-    for (const [jobName, jobData] of Object.entries(jobs)) {
+    for (const [jobName, jobData] of Object.entries(jobs ?? {})) {
       if (jobsConfig[jobName]) {
         throw new Error(`Two jobs with the same name: ${jobName}`)
       }


### PR DESCRIPTION
I *think* that it's possible to have a valid `circle.yml` file in a given directory that looks like the following, i.e. is missing the `jobs` key, if the workflow only uses jobs defined in orbs.

```
version: '2.1'
orbs:
  node: circleci/node@x.y
workflows:
  run-npm-command:
    jobs:
      - node/run:
          npm-run: build
```

If that happens, this line of code breaks without the fallback to an empty object, with exception:

```
Got error: TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at buildConfiguration (/home/circletron/app/dist/index.js:138:49)
    at async triggerCiJobs (/home/circletron/app/dist/index.js:175:27)
```

Not sure if this is the right fix, let me know.