### PR TITLE
Allow running changed packages on target branches

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,3 +63,18 @@ This will cause jobs within `project1` to run when changes are detected in eithe
 ## Details
 
 It is useful to set up branch protection rules to prevent code from being merged when a CI job does not pass. When jobs are omitted then the PR will never be mergeable since the job will remain in a `pending` state. For this reason `circletron` will never omit a job that was determined not to be run, instead the job will be replaced wit a simple job that echos "Job is not required" and return a success exit status.
+
+## Configuration Properties
+
+Circletron configuration can be provided in a `.circle/circletron.yml` file. You can specify target branches using `targetBranches`:
+
+```
+# this is the default value
+targetBranches: ^(release/|main$|master$|develop$)
+```
+
+On target branches, Circletron can be configured to only run workflows in the packages that have changed since the last successful build on that branch. This feature interacts with the Circle API v2, so requires an access token to be provided, via the `CIRCLE_TOKEN` environment variable. You can turn this on using `runOnlyChangedOnTargetBranches`:
+
+```
+runOnlyChangedOnTargetBranches: true
+```

--- a/src/circle.ts
+++ b/src/circle.ts
@@ -69,7 +69,10 @@ interface CircleWorkflows {
   items: CircleWorkflowItem[]
 }
 
-async function find<I>(items: I[], asyncCallback: (input: I) => Promise<boolean>): Promise<I | null> {
+async function find<I>(
+  items: I[],
+  asyncCallback: (input: I) => Promise<boolean>,
+): Promise<I | null> {
   for (const element of items) {
     const shouldReturn: boolean = await asyncCallback(element)
     if (shouldReturn) return element
@@ -81,10 +84,12 @@ async function find<I>(items: I[], asyncCallback: (input: I) => Promise<boolean>
 /**
  * This method determines, for the current branch, the commit hash of the last
  * build executed within Circle CI, by calling the API.
- * 
+ *
  * @returns last commit built in Circle CI on the current branch, or null
  */
-export async function getLastSuccessfulBuildRevisionOnBranch(branch: string): Promise<string | null> {
+export async function getLastSuccessfulBuildRevisionOnBranch(
+  branch: string,
+): Promise<string | null> {
   try {
     // given the build URL, which is of the form https://circleci.com/api/v2/project/{project_slug}/{build_number}
     // we can extract the project slug to call the API
@@ -97,30 +102,41 @@ export async function getLastSuccessfulBuildRevisionOnBranch(branch: string): Pr
     if (projectSlug) {
       // Call the API for pipelines, which tell us nothing about whether all the workflows within them were
       // successful or not
-      const { data: pipelineData } = await axios.get(`${CIRCLE_API_URL}/project/${projectSlug}/pipeline`, {
-        headers: {
-          'Circle-Token': circleToken,
+      const { data: pipelineData } = await axios.get(
+        `${CIRCLE_API_URL}/project/${projectSlug}/pipeline`,
+        {
+          headers: {
+            'Circle-Token': circleToken,
+          },
+          params: {
+            branch,
+          },
         },
-        params: {
-          branch,
-        },
-      })
+      )
 
       // For each pipeline, fetch the workflows and find the first one where all the workflows have a
       // 'success' status
-      const lastSuccessfulBuild = await find((pipelineData as CirclePipelines).items, async item => {
-        if (item.state === CirclePipelineState.Created) {
-          const { data: workflowData } = await axios.get(`${CIRCLE_API_URL}/pipeline/${item.id}/workflow`, {
-            headers: {
-              'Circle-Token': circleToken,
-            },
-          })
+      const lastSuccessfulBuild = await find(
+        (pipelineData as CirclePipelines).items,
+        async (item) => {
+          if (item.state === CirclePipelineState.Created) {
+            const { data: workflowData } = await axios.get(
+              `${CIRCLE_API_URL}/pipeline/${item.id}/workflow`,
+              {
+                headers: {
+                  'Circle-Token': circleToken,
+                },
+              },
+            )
 
-          return (workflowData as CircleWorkflows).items.every(item => item.status === CircleWorkflowStatus.Success)
-        }
+            return (workflowData as CircleWorkflows).items.every(
+              (item) => item.status === CircleWorkflowStatus.Success,
+            )
+          }
 
-        return false
-      })
+          return false
+        },
+      )
 
       return lastSuccessfulBuild?.vcs.revision ?? null
     }

--- a/src/circle.ts
+++ b/src/circle.ts
@@ -1,0 +1,122 @@
+import axios from 'axios'
+
+import { requireEnv } from './env'
+
+const CIRCLE_API_URL = 'https://circleci.com/api/v2'
+
+interface CirclePipelineError {
+  type: string
+  message: string
+}
+
+interface CirclePipelineVCSInfo {
+  // Name of the VCS provider
+  provider_name: 'GitHub' | 'Bitbucket'
+
+  // The code revision the pipeline ran
+  revision: string
+}
+
+enum CirclePipelineState {
+  Created = 'created',
+  Errored = 'errored',
+  SetupPending = 'setup-pending',
+  Setup = 'setup',
+  Pending = 'pending',
+}
+
+interface CirclePipelineItem {
+  // The unique ID of the pipeline
+  id: string
+
+  // A sequence of errors that have occurred within the pipeline
+  errors: CirclePipelineError[]
+
+  // The current state of the pipeline
+  state: CirclePipelineState
+
+  // VCS information for the pipeline
+  vcs: CirclePipelineVCSInfo
+}
+
+interface CirclePipelines {
+  // A list of pipelines
+  items: CirclePipelineItem[]
+}
+
+enum CircleWorkflowStatus {
+  Success = 'success',
+  Running = 'running',
+  NotRun = 'not_run',
+  Failed = 'failed',
+  Error = 'error',
+  Failing = 'failing',
+  OnHold = 'on_hold',
+  Canceled = 'canceled',
+  Unauthorized = 'unauthorized',
+}
+
+interface CircleWorkflowItem {
+  // The unique ID of the workflow
+  id: string
+
+  // The current status of the workflow
+  status: CircleWorkflowStatus
+}
+
+interface CircleWorkflows {
+  // A list of workflows
+  items: CircleWorkflowItem[]
+}
+
+async function find<I>(items: I[], asyncCallback: (input: I) => Promise<boolean>): Promise<I | null> {
+  for (const element of items) {
+    const shouldReturn: boolean = await asyncCallback(element)
+    if (shouldReturn) return element
+  }
+
+  return null
+}
+
+/**
+ * This method determines, for the current branch, the commit hash of the last
+ * build executed within Circle CI, by calling the API.
+ * 
+ * @returns last commit built in Circle CI on the current branch, or null
+ */
+export async function getLastSuccessfulBuildRevisionOnBranch(branch: string): Promise<string | null> {
+  try {
+    // given the build URL, which is of the form https://circleci.com/api/v2/project/{project_slug}/{build_number}
+    // we can extract the project slug to call the API
+    const buildUrl = requireEnv("CIRCLE_BUILD_URL")
+    const projectSlug: string | undefined = /circleci\.com\/(.*\/.*\/.*)\//.exec(buildUrl)?.[1]
+
+    if (projectSlug) {
+      // Call the API for pipelines, which tell us nothing about whether all the workflows within them were
+      // successful or not
+      const { data: pipelineData } = await axios.get(`${CIRCLE_API_URL}/project/${projectSlug}/pipeline`, {
+        params: {
+          branch,
+        },
+      })
+
+      // For each pipeline, fetch the workflows and find the first one where all the workflows have a
+      // 'success' status
+      const lastSuccessfulBuild = await find((pipelineData as CirclePipelines).items, async item => {
+        if (item.state === CirclePipelineState.Created) {
+          const { data: workflowData } = await axios.get(`${CIRCLE_API_URL}/pipeline/${item.id}/workflow`)
+
+          return (workflowData as CircleWorkflows).items.every(item => item.status === CircleWorkflowStatus.Success)
+        }
+
+        return false
+      })
+
+      return lastSuccessfulBuild?.vcs.revision ?? null
+    }
+  } catch (e) {
+
+  }
+
+  return null
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,7 @@
+export const requireEnv = (varName: string): string => {
+  const value = process.env[varName]
+  if (!value) {
+    throw new Error(`Environment variable ${varName} must be set`)
+  }
+  return value
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -77,10 +77,11 @@ export const getBranchpointCommit = async (mainBranchRegex: RegExp): Promise<str
 }
 
 export const getLastCommitOnBranch = async (): Promise<string> => {
-  const stdout = await spawnGetStdout('git', ['log', '-n', '2', '--pretty=format:%h'])
+  const stdout = await spawnGetStdout('git', ['log', 'HEAD@{1}', '-1', '--pretty=format:%h'])
+  const commits = stdout.trim().split('\n', 1)
 
-  if (stdout.trim().split('\n').length > 1) {
-    return stdout.trim().split('\n')[1]
+  if (commits.length > 0) {
+    return commits[0]
   }
 
   throw new Error('Could not find last commit on branch')

--- a/src/git.ts
+++ b/src/git.ts
@@ -75,14 +75,3 @@ export const getBranchpointCommit = async (mainBranchRegex: RegExp): Promise<str
     })
   })
 }
-
-export const getLastCommitOnBranch = async (): Promise<string> => {
-  const stdout = await spawnGetStdout('git', ['log', 'HEAD@{1}', '-1', '--pretty=format:%h'])
-  const commits = stdout.trim().split('\n', 1)
-
-  if (commits.length > 0) {
-    return commits[0]
-  }
-
-  throw new Error('Could not find last commit on branch')
-}

--- a/src/git.ts
+++ b/src/git.ts
@@ -75,3 +75,13 @@ export const getBranchpointCommit = async (mainBranchRegex: RegExp): Promise<str
     })
   })
 }
+
+export const getLastCommitOnBranch = async (): Promise<string> => {
+  const stdout = await spawnGetStdout('git', ['log', '-n', '2', '--pretty=format:%h'])
+
+  if (stdout.trim().split('\n').length > 1) {
+    return stdout.trim().split('\n')[1]
+  }
+
+  throw new Error('Could not find last commit on branch')
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ async function buildConfiguration(
 }
 
 export async function getCircletronConfig(): Promise<CircletronConfig> {
-  let rawConfig: { targetBranches?: string, runOnlyChangedOnTargetBranches?: boolean } = {}
+  let rawConfig: { targetBranches?: string; runOnlyChangedOnTargetBranches?: boolean } = {}
   try {
     rawConfig = yamlParse((await pReadFile(pathJoin('.circleci', 'circletron.yml'))).toString())
   } catch (e) {
@@ -207,9 +207,10 @@ export async function getCircletronConfig(): Promise<CircletronConfig> {
   }
 
   return {
-    runOnlyChangedOnTargetBranches: rawConfig.runOnlyChangedOnTargetBranches !== undefined
-      ? rawConfig.runOnlyChangedOnTargetBranches
-      : DEFAULT_RUN_ONLY_CHANGED_ON_TARGET_BRANCHES,
+    runOnlyChangedOnTargetBranches:
+      rawConfig.runOnlyChangedOnTargetBranches !== undefined
+        ? rawConfig.runOnlyChangedOnTargetBranches
+        : DEFAULT_RUN_ONLY_CHANGED_ON_TARGET_BRANCHES,
     targetBranchesRegex: rawConfig.targetBranches
       ? new RegExp(rawConfig.targetBranches)
       : DEFAULT_TARGET_BRANCHES_REGEX,

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,18 +76,22 @@ const getTriggerPackages = async (
 
   let changesSinceCommit: string
 
-  if (isTargetBranch && config.runOnlyChangedOnTargetBranches) {
-    const lastBuildCommit: string | null = await getLastSuccessfulBuildRevisionOnBranch(branch)
+  if (isTargetBranch) {
+    if (config.runOnlyChangedOnTargetBranches) {
+      const lastBuildCommit: string | undefined = await getLastSuccessfulBuildRevisionOnBranch(
+        branch,
+      )
 
-    if (lastBuildCommit === null) {
-      console.log(`Could not find a previous build on ${branch}, running all pipelines`)
+      if (!lastBuildCommit) {
+        console.log(`Could not find a previous build on ${branch}, running all pipelines`)
+        return allPackageNames
+      }
+
+      changesSinceCommit = lastBuildCommit
+    } else {
+      console.log(`Detected a push from ${branch}, running all pipelines`)
       return allPackageNames
     }
-
-    changesSinceCommit = lastBuildCommit
-  } else if (isTargetBranch) {
-    console.log(`Detected a push from ${branch}, running all pipelines`)
-    return allPackageNames
   } else {
     changesSinceCommit = await getBranchpointCommit(config.targetBranchesRegex)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,12 @@ const getTriggerPackages = async (
     console.log(`Detected a push from ${branch}, running all pipelines`)
     return allPackageNames
   } else if (isTargetBranch) {
-    changesSinceCommit = await getLastCommitOnBranch()
+    try {
+      changesSinceCommit = await getLastCommitOnBranch()
+    } catch (e) {
+      console.log(`Could not find a previous commit on ${branch}, running all pipelines`)
+      return allPackageNames
+    }
   } else {
     changesSinceCommit = await getBranchpointCommit(config.targetBranchesRegex)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,9 +212,7 @@ export async function getCircletronConfig(): Promise<CircletronConfig> {
 
   return {
     runOnlyChangedOnTargetBranches:
-      rawConfig.runOnlyChangedOnTargetBranches !== undefined
-        ? rawConfig.runOnlyChangedOnTargetBranches
-        : DEFAULT_RUN_ONLY_CHANGED_ON_TARGET_BRANCHES,
+      rawConfig.runOnlyChangedOnTargetBranches ?? DEFAULT_RUN_ONLY_CHANGED_ON_TARGET_BRANCHES,
     targetBranchesRegex: rawConfig.targetBranches
       ? new RegExp(rawConfig.targetBranches)
       : DEFAULT_TARGET_BRANCHES_REGEX,


### PR DESCRIPTION
I'm not sure whether this fits with where the maintainers see Circletron going, but I thought I'd open a PR to see what you all think.

Right now, every change to a target branch triggers all jobs across all packages. My feeling is that as a user of the orb, I should be able to set a configuration flag to only run jobs against changed packages.